### PR TITLE
Add transaction tests and CI integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    needs: test
     runs-on: ubuntu-latest
     
     steps:
@@ -59,3 +60,6 @@ jobs:
       
     - name: Type check
       run: npx tsc --noEmit || echo "Type checking skipped - no tsconfig found"
+
+    - name: Run unit tests
+      run: npm test --if-present

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ src/
 - `npm run build`: Compila la aplicación para producción.
 - `npm run preview`: Previsualiza la build de producción.
 - `npm run deploy:cloudflare`: Despliega la aplicación en Cloudflare Pages.
+- `npm test`: Ejecuta la suite de pruebas con Vitest.
 
 ## CI/CD con GitHub Actions
 
 El repositorio está configurado con un workflow de GitHub Actions (`.github/workflows/deploy.yml`) para la integración y despliegue continuo en Cloudflare Pages. El workflow se dispara en cada `push` a la rama `main`.
+Las pruebas unitarias y de integración se ejecutan automáticamente y deben aprobarse antes de realizar el despliegue.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy:cloudflare": "npm run build && npx wrangler pages deploy"
+    "deploy:cloudflare": "npm run build && npx wrangler pages deploy",
+    "test": "vitest"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.0.0",
@@ -19,7 +20,10 @@
     "svelte-preprocess": "^5.0.0",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.0.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "@testing-library/svelte": "^4.2.1",
+    "jsdom": "^22.1.0"
   },
   "dependencies": {
     "chart.js": "^4.5.0",

--- a/src/lib/server/transactions.ts
+++ b/src/lib/server/transactions.ts
@@ -1,0 +1,36 @@
+import { ObjectId, type Db } from 'mongodb';
+import type { Transaction } from '../types';
+
+/**
+ * Validates a transaction ensuring amount, type and date are correct.
+ */
+export function validateTransaction(t: Transaction): boolean {
+  if (typeof t.amount !== 'number' || Number.isNaN(t.amount)) return false;
+  if (t.type !== 'income' && t.type !== 'expense') return false;
+  if (!t.date || Number.isNaN(Date.parse(t.date))) return false;
+  return true;
+}
+
+/** Inserts a new transaction and returns its id. */
+export async function createTransaction(db: Db, t: Transaction) {
+  const result = await db.collection('transactions').insertOne(t);
+  return result.insertedId.toString();
+}
+
+/** Returns all transactions sorted by date desc. */
+export async function listTransactions(db: Db): Promise<Transaction[]> {
+  const raw = await db.collection('transactions').find({}).sort({ date: -1 }).toArray();
+  return raw.map((t: any) => ({ ...t, _id: t._id.toString(), date: new Date(t.date).toISOString() }));
+}
+
+/** Updates a transaction by id. Returns true if modified. */
+export async function updateTransaction(db: Db, id: string, data: Partial<Transaction>) {
+  const result = await db.collection('transactions').updateOne({ _id: new ObjectId(id) }, { $set: data });
+  return result.modifiedCount > 0;
+}
+
+/** Deletes a transaction by id. Returns true if removed. */
+export async function deleteTransaction(db: Db, id: string) {
+  const result = await db.collection('transactions').deleteOne({ _id: new ObjectId(id) });
+  return result.deletedCount > 0;
+}

--- a/src/routes/api/transactions/+server.ts
+++ b/src/routes/api/transactions/+server.ts
@@ -1,10 +1,17 @@
 import { getDb } from '$lib/server/db';
 import { json } from '@sveltejs/kit';
+import {
+  validateTransaction,
+  createTransaction,
+  listTransactions,
+  updateTransaction,
+  deleteTransaction
+} from '$lib/server/transactions';
 
 export async function GET() {
   try {
     const db = await getDb();
-    const transactions = await db.collection('transactions').find({}).sort({ date: -1 }).toArray();
+    const transactions = await listTransactions(db);
     return json({ transactions }, { status: 200 });
   } catch (error) {
     return json({ error: 'Error al obtener transacciones' }, { status: 500 });
@@ -16,10 +23,39 @@ export async function POST({ request }) {
     const db = await getDb();
     const transaction = await request.json();
 
-    const result = await db.collection('transactions').insertOne(transaction);
+    if (!validateTransaction(transaction)) {
+      return json({ error: 'Datos de transacción inválidos' }, { status: 400 });
+    }
 
-    return json({ id: result.insertedId }, { status: 201 });
+    const id = await createTransaction(db, transaction);
+
+    return json({ id }, { status: 201 });
   } catch (error) {
     return json({ error: 'Error al guardar la transacción' }, { status: 500 });
+  }
+}
+
+export async function PUT({ request }) {
+  try {
+    const db = await getDb();
+    const body = await request.json();
+    const { id, ...data } = body;
+    if (!id) return json({ error: 'ID requerido' }, { status: 400 });
+    await updateTransaction(db, id, data);
+    return json({ ok: true }, { status: 200 });
+  } catch (error) {
+    return json({ error: 'Error al actualizar transacción' }, { status: 500 });
+  }
+}
+
+export async function DELETE({ url }) {
+  try {
+    const db = await getDb();
+    const id = url.searchParams.get('id');
+    if (!id) return json({ error: 'ID requerido' }, { status: 400 });
+    await deleteTransaction(db, id);
+    return json({ ok: true }, { status: 200 });
+  } catch (error) {
+    return json({ error: 'Error al eliminar transacción' }, { status: 500 });
   }
 }

--- a/tests/integration/transactions-api.test.ts
+++ b/tests/integration/transactions-api.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET, POST, PUT, DELETE } from '../../src/routes/api/transactions/+server';
+import * as dbMod from '../../src/lib/server/db';
+
+// Simple in-memory collection used to mock MongoDB methods
+const store: any[] = [];
+
+const mockDb = {
+  collection: () => ({
+    find: () => ({ sort: () => ({ toArray: async () => store }) }),
+    insertOne: async (doc: any) => {
+      const newDoc = { ...doc, _id: String(store.length + 1) };
+      store.push(newDoc);
+      return { insertedId: newDoc._id };
+    },
+    updateOne: async (filter: any, update: any) => {
+      const idx = store.findIndex((d) => d._id === String(filter._id));
+      if (idx >= 0) {
+        store[idx] = { ...store[idx], ...update.$set };
+        return { modifiedCount: 1 };
+      }
+      return { modifiedCount: 0 };
+    },
+    deleteOne: async (filter: any) => {
+      const idx = store.findIndex((d) => d._id === String(filter._id));
+      if (idx >= 0) {
+        store.splice(idx, 1);
+        return { deletedCount: 1 };
+      }
+      return { deletedCount: 0 };
+    }
+  })
+};
+
+// Mock getDb to return our in-memory DB
+vi.spyOn(dbMod, 'getDb').mockResolvedValue(mockDb as any);
+
+beforeEach(() => {
+  store.length = 0; // reset between tests
+});
+
+describe('transactions API endpoints', () => {
+  it('creates and lists transactions', async () => {
+    await POST({ request: new Request('http://test', { method: 'POST', body: JSON.stringify({ amount: 5, category: 'Food', type: 'expense', date: '2024-01-02' }), headers: { 'Content-Type': 'application/json' } }) });
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.transactions.length).toBe(1);
+  });
+
+  it('updates a transaction', async () => {
+    const create = await POST({ request: new Request('http://t', { method: 'POST', body: JSON.stringify({ amount: 1, category: 'Food', type: 'expense', date: '2024-01-02' }), headers: { 'Content-Type': 'application/json' } }) });
+    const created = await create.json();
+
+    await PUT({ request: new Request('http://t', { method: 'PUT', body: JSON.stringify({ id: created.id, category: 'Drink' }), headers: { 'Content-Type': 'application/json' } }) });
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.transactions[0].category).toBe('Drink');
+  });
+
+  it('deletes a transaction', async () => {
+    const create = await POST({ request: new Request('http://t', { method: 'POST', body: JSON.stringify({ amount: 3, category: 'X', type: 'income', date: '2024-01-02' }), headers: { 'Content-Type': 'application/json' } }) });
+    const created = await create.json();
+
+    await DELETE({ url: new URL('http://t?id=' + created.id) });
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.transactions.length).toBe(0);
+  });
+});

--- a/tests/unit/transactions.test.ts
+++ b/tests/unit/transactions.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { validateTransaction } from '../../src/lib/server/transactions';
+
+// Example valid transaction used in multiple tests
+const base = { amount: 10, category: 'Food', type: 'expense', date: '2024-01-01' };
+
+describe('validateTransaction', () => {
+  it('accepts a valid transaction', () => {
+    expect(validateTransaction(base)).toBe(true);
+  });
+
+  it('rejects invalid amount', () => {
+    expect(validateTransaction({ ...base, amount: NaN })).toBe(false);
+  });
+
+  it('rejects invalid type', () => {
+    // type must be "income" or "expense"
+    expect(validateTransaction({ ...base, type: 'other' as any })).toBe(false);
+  });
+
+  it('rejects invalid date', () => {
+    expect(validateTransaction({ ...base, date: 'invalid' })).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import { sveltekit } from '@sveltejs/kit/vite';
+
+export default defineConfig({
+  plugins: [sveltekit()],
+  test: {
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- create reusable MongoDB CRUD helpers with validation
- extend transaction API with update and delete endpoints
- add unit and integration tests using Vitest
- integrate `npm test` into GitHub Actions
- document testing workflow in README

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a304132fc8330a597f45a86951bc3